### PR TITLE
chore: docs updates and use some defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Each Falco driver-specific deployment under `./kustomize/driver/{ebpf,kmod,moder
 
 | Knode   | Falco Driver | Namespace | Node Selector                           |
 |---------|--------------|-----------|----------------------------------------|
-| knode A | modern-bpf   | falco     | cncf-project: "falco"                  |
+| knode A | modern-ebpf   | falco     | cncf-project: "falco"                  |
 |         |              |           | cncf-project-sub: "falco-driver-modern-ebpf" |
-| knode B | bpf          | falco     | cncf-project: "falco"                  |
+| knode B | ebpf          | falco     | cncf-project: "falco"                  |
 |         |              |           | cncf-project-sub: "falco-driver-ebpf"   |
 | knode C | kmod         | falco     | cncf-project: "falco"                  |
 |         |              |           | cncf-project-sub: "falco-driver-kmod"  |
@@ -65,22 +65,20 @@ Each Falco driver-specific deployment under `./kustomize/driver/{ebpf,kmod,moder
 | Knode   | Kernel Version Requirement | Additional Requirements  | BPF Stats Enabled |
 |---------|---------------------------|--------------------------|-------------------|
 | knode A | >= 5.8                    | eBPF supported           | 1                 |
-| knode B | >= 4.14                   | eBPF supported           | 1                 |
-| knode C | >= 2.6.32                 | DKMS package installed   | N/A               |
-
+| knode B | >= 4.14                   | eBPF supported, Kernel headers installed           | 1                 |
+| knode C | >= 2.6.32                 | DKMS package, Kernel headers installed   | N/A               |
 
 Notes:
 - The Falco Deployment enables `kernel.bpf_stats_enabled` by default.
 - For both `ebpf` and `kmod`, additional host mounts are required, such as `/usr/src/` and `/lib/modules`. Please refer to the respective daemonset configuration for more details.
 - We anticipate `containerd` to be the container runtime socket located at `/run/containerd/containerd.sock`.
 
-
 ## HowTo: A Guide for `localhost` Testing
 
 <details>
 	<summary>Expand Testing Instructions</summary>
 
-To test these configurations for the modern BPF driver on localhost using [minikube](https://minikube.sigs.k8s.io/docs/start/), make sure you have minikube and [kubectl](https://pwittrock.github.io/docs/tasks/tools/install-kubectl/) installed and running. In order to test `kmod` and `ebpf` drivers, additional host mounts are required. Minikube needs a specific setting to accommodate this, as shown below:
+To test these configurations on localhost using [minikube](https://minikube.sigs.k8s.io/docs/start/), make sure you have minikube and [kubectl](https://pwittrock.github.io/docs/tasks/tools/install-kubectl/) installed and running. In order to test `kmod` and `ebpf` drivers, additional host mounts are required. Minikube needs a specific setting to accommodate this, as shown below:
 
 ```
 minikube start --mount --mount-string="/usr/src:/usr/src" --mount --mount-string="/dev:/dev" --driver=docker --nodes 4
@@ -96,13 +94,13 @@ Proceed by executing the following setup commands:
 kubectl create namespace falco;
 kubectl get nodes;
 
-# Test modern-bpf (easiest)
+# Test cncf-project-sub=falco-driver-modern-ebpf (easiest)
 kubectl label nodes minikube-m02 cncf-project=falco cncf-project-sub=falco-driver-modern-ebpf --overwrite;
 
-# Test bpf
+# Test cncf-project-sub=falco-driver-ebpf
 kubectl label nodes minikube-m03 cncf-project=falco cncf-project-sub=falco-driver-ebpf --overwrite;
 
-# Test kmod
+# Test cncf-project-sub=falco-driver-kmod
 # WARNING: Testing kernel modules on a local dev box is more risky, 
 # remember to unload the module `sudo rmmod falco`
 # Testing kmod within a smaller VM with minikube likely crashes, only test w/ minikube on a larger native box

--- a/kustomize/falco-driver/ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/ebpf/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
           touch /tmp/falco/events.jsonl &&
           logrotate -f /etc/falco/logrotate.conf &&
           export FALCO_HOSTNAME="${FALCO_HOSTNAME}_${CONFIG_VERSION}" &&
-          /usr/bin/falco --cri /run/containerd/containerd.sock -pk --disable-cri-async
+          /usr/bin/falco -pk --disable-cri-async
         volumeMounts:
         - mountPath: /etc/falco
           name: rulesfiles-install-dir
@@ -85,23 +85,8 @@ spec:
       - name: falco-driver-loader
         image: docker.io/falcosecurity/falco-driver-loader:master
         imagePullPolicy: IfNotPresent
-        # args:
-        #   - ebpf
-        # todo we are still investigating driver-loader issues in general and better ways to support testing w/ minikube
-        # consider below override experimental for now to support minikube testing as well
-        command: ["/bin/bash", "-c"]
         args:
-        - |
-          if [ "$(ls -A ${HOST_ROOT}/usr/src/kernels/$(uname -r))" ]; then
-              echo "RPM based distro"
-              mkdir -p /usr/src/kernels/ && cp -r ${HOST_ROOT}/usr/src/kernels/$(uname -r) /usr/src/kernels/$(uname -r) &&
-              /usr/bin/falcoctl driver config --type ebpf && /usr/bin/falcoctl driver install --compile=true --download=true
-          elif [ "$(ls -A ${HOST_ROOT}/usr/src/linux-headers-$(uname -r))" ]; then
-              echo "Ubuntu distro"
-              cp -r $(ls -d ${HOST_ROOT}/usr/src/* | head -n 1) /usr/src/ &&
-              cp -r $(ls -d ${HOST_ROOT}/usr/src/linux-headers-$(uname -r) | head -n 1) /usr/src/linux-headers-$(uname -r) &&
-              /usr/bin/falcoctl driver config --type ebpf && /usr/bin/falcoctl driver install --compile=true --download=true
-          fi
+          - ebpf
         securityContext:
           privileged: true
         volumeMounts:

--- a/kustomize/falco-driver/kmod/daemonset.yaml
+++ b/kustomize/falco-driver/kmod/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
           touch /tmp/falco/events.jsonl &&
           logrotate -f /etc/falco/logrotate.conf &&
           export FALCO_HOSTNAME="${FALCO_HOSTNAME}_${CONFIG_VERSION}" &&
-          /usr/bin/falco --cri /run/containerd/containerd.sock -pk --disable-cri-async
+          /usr/bin/falco -pk --disable-cri-async
         volumeMounts:
         - mountPath: /etc/falco
           name: rulesfiles-install-dir
@@ -84,23 +84,8 @@ spec:
       - name: falco-driver-loader
         image: docker.io/falcosecurity/falco-driver-loader:master
         imagePullPolicy: IfNotPresent
-        # args: 
-        # - kmod
-        # todo we are still investigating driver-loader issues in general and better ways to support testing w/ minikube
-        # consider below override experimental for now to support minikube testing as well
-        command: ["/bin/bash", "-c"]
-        args:
-        - |
-          if [ "$(ls -A ${HOST_ROOT}/usr/src/kernels/$(uname -r))" ]; then
-              echo "RPM based distro"
-              mkdir -p /usr/src/kernels/ && cp -r ${HOST_ROOT}/usr/src/kernels/$(uname -r) /usr/src/kernels/$(uname -r) &&
-              /usr/bin/falcoctl driver config --type kmod && /usr/bin/falcoctl driver install --compile=true --download=true
-          elif [ "$(ls -A ${HOST_ROOT}/usr/src/linux-headers-$(uname -r))" ]; then
-              echo "Ubuntu distro"
-              cp -r $(ls -d ${HOST_ROOT}/usr/src/* | head -n 1) /usr/src/ &&
-              cp -r $(ls -d ${HOST_ROOT}/usr/src/linux-headers-$(uname -r) | head -n 1) /usr/src/linux-headers-$(uname -r) &&
-              /usr/bin/falcoctl driver config --type kmod && /usr/bin/falcoctl driver install --compile=true --download=true
-          fi
+        args: 
+        - kmod
         securityContext:
           privileged: true
         volumeMounts:

--- a/kustomize/falco-driver/modern_ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/modern_ebpf/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
           touch /tmp/falco/events.jsonl &&
           logrotate -f /etc/falco/logrotate.conf &&
           export FALCO_HOSTNAME="${FALCO_HOSTNAME}_${CONFIG_VERSION}" &&
-          /usr/bin/falco --cri /run/containerd/containerd.sock -pk --disable-cri-async
+          /usr/bin/falco -pk --disable-cri-async
         volumeMounts:
         - mountPath: /etc/falco
           name: rulesfiles-install-dir


### PR DESCRIPTION
- Docs updates
- Rely on default cri socket search logic
- Trust the default driver-loader as we the CNCF testbed is ubuntu 22.04 for which we definitely always have pre-built drivers. For the records: I cannot confirm that driver-loader would work building the driver as backup.