### PR TITLE
update: include all default cri socket locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Each Falco driver-specific deployment under `./kustomize/driver/{ebpf,kmod,moder
 Notes:
 - The Falco Deployment enables `kernel.bpf_stats_enabled` by default.
 - For both `ebpf` and `kmod`, additional host mounts are required, such as `/usr/src/` and `/lib/modules`. Please refer to the respective daemonset configuration for more details.
-- We anticipate `containerd` to be the container runtime socket located at `/run/containerd/containerd.sock`.
+- We anticipate `containerd` to be the container runtime socket located at `/run/k3s/containerd/containerd.sock`.
 
 ## HowTo: A Guide for `localhost` Testing
 
@@ -84,9 +84,11 @@ To test these configurations on localhost using [minikube](https://minikube.sigs
 minikube start --mount --mount-string="/usr/src:/usr/src" --mount --mount-string="/dev:/dev" --driver=docker --nodes 4
 ```
 
-__NOTE__: You won't be able to properly test Falco's container engine using `minikube`. Please be aware of this limitation.
+__NOTE__: You won't be able to properly test Falco's container engine using `minikube`. Please be aware of this limitation, and there can still be issues with host mounts.
 
 __NOTE__: For `localhost` testing reduce the number of replicas for the synthetic workload deployments.
+
+__NOTE__: Finally, we recommend testing on Ubuntu 22.04 to reflect the CNCF testbed setup. You can use the Vagrant VM config shared [here](https://github.com/falcosecurity/cncf-green-review-testing/issues/7).
 
 Proceed by executing the following setup commands:
 

--- a/kustomize/falco-driver/ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/ebpf/daemonset.yaml
@@ -74,6 +74,10 @@ spec:
           name: etc-fs
         - mountPath: /host/run/containerd/containerd.sock
           name: containerd-socket
+        - mountPath: /host/run/k3s/containerd/containerd.sock
+          name: containerd-k3s-socket
+        - mountPath: /host/run/crio/crio.sock
+          name: crio-socket
         - mountPath: /etc/falco/falco.yaml
           name: falco-yaml
           subPath: falco.yaml
@@ -154,6 +158,12 @@ spec:
       - name: containerd-socket
         hostPath:
           path: /run/containerd/containerd.sock
+      - name: containerd-k3s-socket
+        hostPath:
+          path: /run/k3s/containerd/containerd.sock
+      - name: crio-socket
+        hostPath:
+          path: /run/crio/crio.sock
       - name: proc-fs
         hostPath:
           path: /proc

--- a/kustomize/falco-driver/kmod/daemonset.yaml
+++ b/kustomize/falco-driver/kmod/daemonset.yaml
@@ -73,6 +73,10 @@ spec:
           name: etc-fs
         - mountPath: /host/run/containerd/containerd.sock
           name: containerd-socket
+        - mountPath: /host/run/k3s/containerd/containerd.sock
+          name: containerd-k3s-socket
+        - mountPath: /host/run/crio/crio.sock
+          name: crio-socket
         - mountPath: /etc/falco/falco.yaml
           name: falco-yaml
           subPath: falco.yaml
@@ -153,6 +157,12 @@ spec:
       - name: containerd-socket
         hostPath:
           path: /run/containerd/containerd.sock
+      - name: containerd-k3s-socket
+        hostPath:
+          path: /run/k3s/containerd/containerd.sock
+      - name: crio-socket
+        hostPath:
+          path: /run/crio/crio.sock
       - name: proc-fs
         hostPath:
           path: /proc

--- a/kustomize/falco-driver/modern_ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/modern_ebpf/daemonset.yaml
@@ -75,6 +75,10 @@ spec:
           name: etc-fs
         - mountPath: /host/run/containerd/containerd.sock
           name: containerd-socket
+        - mountPath: /host/run/k3s/containerd/containerd.sock
+          name: containerd-k3s-socket
+        - mountPath: /host/run/crio/crio.sock
+          name: crio-socket
         - mountPath: /etc/falco/falco.yaml
           name: falco-yaml
           subPath: falco.yaml
@@ -119,6 +123,12 @@ spec:
       - name: containerd-socket
         hostPath:
           path: /run/containerd/containerd.sock
+      - name: containerd-k3s-socket
+        hostPath:
+          path: /run/k3s/containerd/containerd.sock
+      - name: crio-socket
+        hostPath:
+          path: /run/crio/crio.sock
       - name: proc-fs
         hostPath:
           path: /proc


### PR DESCRIPTION
Noticed we were missing the `/run/k3s/containerd/containerd.sock` and in fact we should just mount all three default container runtime socket paths.

Next would be to tag the new images after Falco 0.37 is out and then everything should be in a good state for trying it out on the CNCF cluster.

@leogr 