### PR TITLE
cleanup: use more conservative baseline settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Notes:
 - The Falco Deployment enables `kernel.bpf_stats_enabled` by default.
 - For both `ebpf` and `kmod`, additional host mounts are required, such as `/usr/src/` and `/lib/modules`. Please refer to the respective daemonset configuration for more details.
 - We anticipate `containerd` to be the container runtime socket located at `/run/k3s/containerd/containerd.sock`.
+- The CNCF test Kubernetes cluster offers machines with 16 CPUs.
 
 ## HowTo: A Guide for `localhost` Testing
 

--- a/kustomize/falco-driver/ebpf/configmap.yaml
+++ b/kustomize/falco-driver/ebpf/configmap.yaml
@@ -24,7 +24,7 @@ data:
   # `json_output` is enabled
   # `json_include_output_property` set to false
   # `json_include_tags_property` set to false
-  # `metrics` is enabled, interval: 2m w/ file output
+  # `metrics` is enabled, interval: 30m w/ file output
   # `priority` set to "info" instead of "debug"
   # `webserver` is disabled
   falco.yaml: |-
@@ -81,7 +81,7 @@ data:
       max_consecutives: 1000
     metrics:
       enabled: true
-      interval: 2m
+      interval: 30m
       output_rule: true
       output_file: /tmp/stats/falco_stats.jsonl
       resource_utilization_enabled: true

--- a/kustomize/falco-driver/ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/ebpf/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          sysctl kernel.bpf_stats_enabled=1 || true &&
+          echo 1 > ${HOST_ROOT}/proc/sys/kernel/bpf_stats_enabled &&
           apt-get update &&
           apt-get install -y logrotate htop jq procps &&
           mkdir -p /tmp/stats &&

--- a/kustomize/falco-driver/ebpf/redis.yaml
+++ b/kustomize/falco-driver/ebpf/redis.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: redis
 spec:
-  replicas: 5
+  replicas: 1
   selector:
     matchLabels:
       app: redis
@@ -32,16 +32,6 @@ spec:
             - -c
             - >-
               while true; do
-                redis-benchmark -h localhost -n 10000000000 -l -c 100 -d 5;
-                sleep 5;
-              done
-        - name: redis-benchmark-2
-          image: redis:7.2.3-alpine
-          command: ["/bin/sh"]
-          args:
-            - -c
-            - >-
-              while true; do
-                redis-benchmark -h localhost -n 1000000000000000 -l -c 300 -d 15;
+                redis-benchmark -h localhost -l -n 100 -c 4;
                 sleep 5;
               done

--- a/kustomize/falco-driver/ebpf/stress-ng.yaml
+++ b/kustomize/falco-driver/ebpf/stress-ng.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: stress-ng
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: stress-ng
@@ -27,17 +27,6 @@ spec:
           apt-get update && 
           apt-get install -y stress-ng &&
           while true; do
-            stress-ng --matrix 0 -t 1m
-            sleep 5
-          done
-      - name: stress-ng-2
-        image: ubuntu:22.04
-        command: ["/bin/bash", "-c"]
-        args:
-        - |
-          apt-get update && 
-          apt-get install -y stress-ng &&
-          while true; do
-            stress-ng --mq 0 -t 30s
+            stress-ng --matrix 1 -t 1m
             sleep 5
           done

--- a/kustomize/falco-driver/kmod/configmap.yaml
+++ b/kustomize/falco-driver/kmod/configmap.yaml
@@ -24,7 +24,7 @@ data:
   # `json_output` is enabled
   # `json_include_output_property` set to false
   # `json_include_tags_property` set to false
-  # `metrics` is enabled, interval: 2m w/ file output
+  # `metrics` is enabled, interval: 30m w/ file output
   # `priority` set to "info" instead of "debug"
   # `webserver` is disabled
   falco.yaml: |-
@@ -81,7 +81,7 @@ data:
       max_consecutives: 1000
     metrics:
       enabled: true
-      interval: 2m
+      interval: 30m
       output_rule: true
       output_file: /tmp/stats/falco_stats.jsonl
       resource_utilization_enabled: true

--- a/kustomize/falco-driver/kmod/redis.yaml
+++ b/kustomize/falco-driver/kmod/redis.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: redis
 spec:
-  replicas: 5
+  replicas: 1
   selector:
     matchLabels:
       app: redis
@@ -32,16 +32,6 @@ spec:
             - -c
             - >-
               while true; do
-                redis-benchmark -h localhost -n 10000000000 -l -c 100 -d 5;
-                sleep 5;
-              done
-        - name: redis-benchmark-2
-          image: redis:7.2.3-alpine
-          command: ["/bin/sh"]
-          args:
-            - -c
-            - >-
-              while true; do
-                redis-benchmark -h localhost -n 1000000000000000 -l -c 300 -d 15;
+                redis-benchmark -h localhost -l -n 100 -c 4;
                 sleep 5;
               done

--- a/kustomize/falco-driver/kmod/stress-ng.yaml
+++ b/kustomize/falco-driver/kmod/stress-ng.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: stress-ng
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: stress-ng
@@ -27,17 +27,6 @@ spec:
           apt-get update && 
           apt-get install -y stress-ng &&
           while true; do
-            stress-ng --matrix 0 -t 1m
-            sleep 5
-          done
-      - name: stress-ng-2
-        image: ubuntu:22.04
-        command: ["/bin/bash", "-c"]
-        args:
-        - |
-          apt-get update && 
-          apt-get install -y stress-ng &&
-          while true; do
-            stress-ng --mq 0 -t 30s
+            stress-ng --matrix 1 -t 1m
             sleep 5
           done

--- a/kustomize/falco-driver/modern_ebpf/configmap.yaml
+++ b/kustomize/falco-driver/modern_ebpf/configmap.yaml
@@ -24,7 +24,7 @@ data:
   # `json_output` is enabled
   # `json_include_output_property` set to false
   # `json_include_tags_property` set to false
-  # `metrics` is enabled, interval: 2m w/ file output
+  # `metrics` is enabled, interval: 30m w/ file output
   # `priority` set to "info" instead of "debug"
   # `webserver` is disabled
   falco.yaml: |-
@@ -81,7 +81,7 @@ data:
       max_consecutives: 1000
     metrics:
       enabled: true
-      interval: 2m
+      interval: 30m
       output_rule: true
       output_file: /tmp/stats/falco_stats.jsonl
       resource_utilization_enabled: true

--- a/kustomize/falco-driver/modern_ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/modern_ebpf/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          sysctl kernel.bpf_stats_enabled=1 || true &&
+          echo 1 > ${HOST_ROOT}/proc/sys/kernel/bpf_stats_enabled &&
           apt-get update &&
           apt-get install -y logrotate htop jq procps &&
           mkdir -p /tmp/stats &&

--- a/kustomize/falco-driver/modern_ebpf/redis.yaml
+++ b/kustomize/falco-driver/modern_ebpf/redis.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: redis
 spec:
-  replicas: 5
+  replicas: 1
   selector:
     matchLabels:
       app: redis
@@ -32,16 +32,6 @@ spec:
             - -c
             - >-
               while true; do
-                redis-benchmark -h localhost -n 10000000000 -l -c 100 -d 5;
-                sleep 5;
-              done
-        - name: redis-benchmark-2
-          image: redis:7.2.3-alpine
-          command: ["/bin/sh"]
-          args:
-            - -c
-            - >-
-              while true; do
-                redis-benchmark -h localhost -n 1000000000000000 -l -c 300 -d 15;
+                redis-benchmark -h localhost -l -n 100 -c 4;
                 sleep 5;
               done

--- a/kustomize/falco-driver/modern_ebpf/stress-ng.yaml
+++ b/kustomize/falco-driver/modern_ebpf/stress-ng.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: stress-ng
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: stress-ng
@@ -27,17 +27,6 @@ spec:
           apt-get update && 
           apt-get install -y stress-ng &&
           while true; do
-            stress-ng --matrix 0 -t 1m
-            sleep 5
-          done
-      - name: stress-ng-2
-        image: ubuntu:22.04
-        command: ["/bin/bash", "-c"]
-        args:
-        - |
-          apt-get update && 
-          apt-get install -y stress-ng &&
-          while true; do
-            stress-ng --mq 0 -t 30s
+            stress-ng --matrix 1 -t 1m
             sleep 5
           done


### PR DESCRIPTION

- Didn't expect bare machines with only 16 CPUs. 
- Adopt conservative baseline configs as new default baseline. 
- Fixed enabling libbpf stats

@leogr 