### PR TITLE
fix: Change image and flag for falco 0.40.0 release 

### DIFF
--- a/kustomize/falco-driver/ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/ebpf/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: falco
-        image: docker.io/falcosecurity/falco-no-driver:0.37.0
+        image: docker.io/falcosecurity/falco:0.40.0-debian
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/kustomize/falco-driver/ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/ebpf/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
           touch /tmp/falco/events.jsonl &&
           logrotate -f /etc/falco/logrotate.conf &&
           export FALCO_HOSTNAME="${FALCO_HOSTNAME}_${CONFIG_VERSION}" &&
-          /usr/bin/falco -pk --disable-cri-async
+          /usr/bin/falco -pk -o container_engines.cri.disable_async=true
         volumeMounts:
         - mountPath: /etc/falco
           name: rulesfiles-install-dir

--- a/kustomize/falco-driver/kmod/daemonset.yaml
+++ b/kustomize/falco-driver/kmod/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: falco
-        image: docker.io/falcosecurity/falco-no-driver:0.37.0
+        image: docker.io/falcosecurity/falco:0.40.0-debian
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/kustomize/falco-driver/kmod/daemonset.yaml
+++ b/kustomize/falco-driver/kmod/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
           touch /tmp/falco/events.jsonl &&
           logrotate -f /etc/falco/logrotate.conf &&
           export FALCO_HOSTNAME="${FALCO_HOSTNAME}_${CONFIG_VERSION}" &&
-          /usr/bin/falco -pk --disable-cri-async
+          /usr/bin/falco -pk -o container_engines.cri.disable_async=true
         volumeMounts:
         - mountPath: /etc/falco
           name: rulesfiles-install-dir

--- a/kustomize/falco-driver/modern_ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/modern_ebpf/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: falco
-        image: docker.io/falcosecurity/falco-no-driver:0.37.0
+        image: docker.io/falcosecurity/falco:0.40.0-debian
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/kustomize/falco-driver/modern_ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/modern_ebpf/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
           touch /tmp/falco/events.jsonl &&
           logrotate -f /etc/falco/logrotate.conf &&
           export FALCO_HOSTNAME="${FALCO_HOSTNAME}_${CONFIG_VERSION}" &&
-          /usr/bin/falco -pk --disable-cri-async
+          /usr/bin/falco -pk -o container_engines.cri.disable_async=true
         volumeMounts:
         - mountPath: /etc/falco
           name: rulesfiles-install-dir


### PR DESCRIPTION
We've having some pipeline errors when deploying the latest 0.40.0 release.

This updates the manifests as per https://falco.org/blog/falco-0-40-0/#breaking-changes-and-deprecations

Thank you for the blog post it was very helpful! 

Pls let me know if there are any other changes I've missed.