### PR TITLE
update: Falco 0.41.1

### DIFF
--- a/kustomize/falco-driver/ebpf/configmap.yaml
+++ b/kustomize/falco-driver/ebpf/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco-driver-ebpf
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 data:
   # --- falco.yaml ---
   # The following configs deviate from the default falco.yaml

--- a/kustomize/falco-driver/ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/ebpf/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco-driver-ebpf
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 spec:
   selector:
     matchLabels:
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: falco
-        image: docker.io/falcosecurity/falco:0.41.0-debian
+        image: docker.io/falcosecurity/falco:0.41.1-debian
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -77,7 +77,7 @@ spec:
           subPath: falco.yaml
       initContainers:
       - name: falco-driver-loader
-        image: docker.io/falcosecurity/falco-driver-loader:0.41.0
+        image: docker.io/falcosecurity/falco-driver-loader:0.41.1
         imagePullPolicy: IfNotPresent
         args:
           - ebpf

--- a/kustomize/falco-driver/kmod/configmap.yaml
+++ b/kustomize/falco-driver/kmod/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco-driver-kmod
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 data:
   # --- falco.yaml ---
   # The following configs deviate from the default falco.yaml

--- a/kustomize/falco-driver/kmod/daemonset.yaml
+++ b/kustomize/falco-driver/kmod/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco-driver-kmod
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 spec:
   selector:
     matchLabels:
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: falco
-        image: docker.io/falcosecurity/falco:0.41.0-debian
+        image: docker.io/falcosecurity/falco:0.41.1-debian
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -76,7 +76,7 @@ spec:
           subPath: falco.yaml
       initContainers:
       - name: falco-driver-loader
-        image: docker.io/falcosecurity/falco-driver-loader:0.41.0
+        image: docker.io/falcosecurity/falco-driver-loader:0.41.1
         imagePullPolicy: IfNotPresent
         args: 
         - kmod

--- a/kustomize/falco-driver/modern_ebpf/configmap.yaml
+++ b/kustomize/falco-driver/modern_ebpf/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco-driver-modern-ebpf
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 data:
   # --- falco.yaml ---
   # The following configs deviate from the default falco.yaml

--- a/kustomize/falco-driver/modern_ebpf/daemonset.yaml
+++ b/kustomize/falco-driver/modern_ebpf/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco-driver-modern-ebpf
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 spec:
   selector:
     matchLabels:
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: falco
-        image: docker.io/falcosecurity/falco:0.41.0-debian
+        image: docker.io/falcosecurity/falco:0.41.1-debian
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/kustomize/falco-generic/falcoctl-configmap.yaml
+++ b/kustomize/falco-generic/falcoctl-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 data:
   falcoctl.yaml: |-
     artifact:

--- a/kustomize/falco-generic/serviceaccount.yaml
+++ b/kustomize/falco-generic/serviceaccount.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: falco
   labels:
     app.kubernetes.io/name: falco
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.41.1"
 ---


### PR DESCRIPTION
update: Falco 0.41.1

Important to promote seamless adoption of the Prometheus metrics on the CNCF test cluster since we now safe-guard inspector initialization better for the Prometheus metrics.

@leogr thanks in advance!

CC @nikimanoledaki @rossf7 